### PR TITLE
Add LIFO queue option for recursive download

### DIFF
--- a/doc/wget.texi
+++ b/doc/wget.texi
@@ -1916,6 +1916,10 @@ case.
 Turn on recursive retrieving.  @xref{Recursive Download}, for more
 details.  The default maximum depth is 5.
 
+@item --queue-type=@var{queuetype}
+Specify the queue type (@pxref{Recursive Download}). Accepted values are @samp{fifo} (the default)
+and @samp{lifo}.
+
 @item -l @var{depth}
 @itemx --level=@var{depth}
 Specify recursion maximum depth level @var{depth} (@pxref{Recursive
@@ -2295,6 +2299,14 @@ document, then the documents linked from that document, then the
 documents linked by them, and so on.  In other words, Wget first
 downloads the documents at depth 1, then those at depth 2, and so on
 until the specified maximum depth.
+
+The @dfn{queue type} is FIFO (default) or LIFO. FIFO download (dequeue)
+the first enqueued files first. LIFO download the last enqueued files
+first. LIFO can prevent that links expire before they're downloaded
+because it downloads them directly after their parent page and
+therefore directly after the parent page and its temporary links are
+generated if it's a dynamic page. Pages sometimes use temporary links
+to prevent direct links to files.
 
 The maximum @dfn{depth} to which the retrieval may descend is specified
 with the @samp{-l} option.  The default maximum depth is five layers.

--- a/src/init.c
+++ b/src/init.c
@@ -104,6 +104,7 @@ CMD_DECLARE (cmd_spec_htmlify);
 CMD_DECLARE (cmd_spec_mirror);
 CMD_DECLARE (cmd_spec_prefer_family);
 CMD_DECLARE (cmd_spec_progress);
+CMD_DECLARE (cmd_spec_queue_type);
 CMD_DECLARE (cmd_spec_recursive);
 CMD_DECLARE (cmd_spec_regex_type);
 CMD_DECLARE (cmd_spec_restrict_file_names);
@@ -247,6 +248,7 @@ static const struct {
   { "proxypasswd",      &opt.proxy_passwd,      cmd_string }, /* deprecated */
   { "proxypassword",    &opt.proxy_passwd,      cmd_string },
   { "proxyuser",        &opt.proxy_user,        cmd_string },
+  { "queuetype",        &opt.queue_type,        cmd_spec_queue_type },
   { "quiet",            &opt.quiet,             cmd_boolean },
   { "quota",            &opt.quota,             cmd_bytes_sum },
 #ifdef HAVE_SSL
@@ -402,6 +404,8 @@ defaults (void)
   opt.restrict_files_ctrl = true;
   opt.restrict_files_nonascii = false;
   opt.restrict_files_case = restrict_no_case_restriction;
+
+  opt.queue_type = queue_type_fifo;
 
   opt.regex_type = regex_type_posix;
 
@@ -1439,6 +1443,23 @@ cmd_spec_recursive (const char *com, const char *val, void *place_ignored _GL_UN
         opt.dirstruct = true;
     }
   return true;
+}
+
+/* Validate --queue-type and set the choice.  */
+
+static bool
+cmd_spec_queue_type (const char *com, const char *val, void *place_ignored _GL_UNUSED)
+{
+  static const struct decode_item choices[] = {
+    { "fifo", queue_type_fifo },
+    { "lifo", queue_type_lifo },
+  };
+  int queue_type = queue_type_fifo;
+  int ok = decode_string (val, choices, countof (choices), &queue_type);
+  if (!ok)
+    fprintf (stderr, _("%s: %s: Invalid value %s.\n"), exec_name, com, quote (val));
+  opt.queue_type = queue_type;
+  return ok;
 }
 
 /* Validate --regex-type and set the choice.  */

--- a/src/main.c
+++ b/src/main.c
@@ -272,6 +272,7 @@ static struct cmdline_option option_data[] =
     { "proxy-passwd", 0, OPT_VALUE, "proxypassword", -1 }, /* deprecated */
     { "proxy-password", 0, OPT_VALUE, "proxypassword", -1 },
     { "proxy-user", 0, OPT_VALUE, "proxyuser", -1 },
+    { "queue-type", 0, OPT_VALUE, "queuetype", -1 },
     { "quiet", 'q', OPT_BOOLEAN, "quiet", -1 },
     { "quota", 'Q', OPT_VALUE, "quota", -1 },
     { "random-file", 0, OPT_VALUE, "randomfile", -1 },
@@ -736,6 +737,8 @@ WARC options:\n"),
 Recursive download:\n"),
     N_("\
   -r,  --recursive                 specify recursive download\n"),
+    N_("\
+       --queue-type=TYPE           queue type (fifo|lifo).\n"),
     N_("\
   -l,  --level=NUMBER              maximum recursion depth (inf or 0 for infinite)\n"),
     N_("\

--- a/src/options.h
+++ b/src/options.h
@@ -46,6 +46,10 @@ struct options
   bool relative_only;           /* Follow only relative links. */
   bool no_parent;               /* Restrict access to the parent
                                    directory.  */
+  enum {
+    queue_type_fifo,
+    queue_type_lifo
+  } queue_type;                 /* Recursion queue type */
   int reclevel;                 /* Maximum level of recursion */
   bool dirstruct;               /* Do we build the directory structure
                                    as we go along? */


### PR DESCRIPTION
## basic problem

the basic problem is that the FIFO queue can create a long time between downloading a page and its links. this is different from the browser experience that the page is designed for. resulting in wget fail that a browser user dont experience


## savannah link

this patch is also posted at https://savannah.gnu.org/bugs/?37581


## making it optional

>To get your patch into git please add a command-line option to activate LIFO behavior. 

k the patch is changed here https://github.com/mirror/wget/pull/1

the patch file is https://github.com/mirror/wget/pull/1.patch


## reason to place html pages at the top of the queue

if ll_bubblesort isn't used only the deepest level links are downloaded directly after its parent page despite using LIFO


## alternative solution

### enqueue child directly after parent seem difficult

another solution is to enqueue the depth n+1 links directly after enqueuing its parent depth n link instead of continuing enqueuing depth n links

this require interrupting the depth n enqueue at html links. dequeue everything (including the html link). enqueue the depth n+1 links. and the continue the depth n enqueue. this require a big reorganization or doesnt make sense

a way to do this could be to store the non-enqueued links in a temporary queue and enqueue them after everything else


the LIFO solution is better than this solution bc

* it's simpler code

* the only benefit is small: that it would download html pages from top to bottom instead of in an arbitrary order (sort place html pages on top of the queue in an arbitrary order)


### enqueue html last doesnt work

keeping FIFO and enqueue html links last (with sort) doesnt solve the problem because all depth n links are still downloaded before any depth n+1 links



## test case description

>I am not sure why you expect that all the resources from 60 "branches" can be downloaded in less than 60s when the "branches" itself can't.

i dont mean that all resources can be downloaded fast. i just mean that they are downloaded directly after the page that contain them

the example is an image hosting site (imagevenue.com) where all images has its own html page (imagevenue.com/img.php) with a generated image link that expires a while after the html page is generated to prevent links directly to image files

all links can be downloaded with lifo because each branch page has only 1 link in this example and there's more than enough time to download that 1 link if the download begin directly after the link is generated

if a branch page (f.e. imagevenue.com/img.php) had many images (links) there could still be a problem. but the problem would be the same for regular users (browsers) that download the resource directly after the page is loaded and the fault is therefore the site's rather than wget's




## test

### imagevenue fail

this fails to download the imagevenue.com/img.php images because it's downloading all the img.php pages before the temporary image links in them, and by the time it gets to them they're expired

	wget -rHpE -l1 -t2 -T10 -np -nc -nH -nd -e robots=off -D'imagevenue.com' -R'th_*.jpg,th_*.JPG,.gif,.png,.css,.js' http://forum.glam0ur.com/hot-babe-galleries/11956-merilyn-sekova-aka-busty-merilyn.html

this downloads images directly after a img.php page is downloaded so they dont have time to expire

	wget -rHpE -l1 -t2 -T10 -np -nc -nH -nd --queue-type=lifo -e robots=off -D'imagevenue.com' -R'th_*.jpg,th_*.JPG,.gif,.png,.css,.js' http://forum.glam0ur.com/hot-babe-galleries/11956-merilyn-sekova-aka-busty-merilyn.html
	

### invalid input

invalid input is prevented

	wget --queue-type=fiffo
	
	wget: --queue-type: Invalid value ‘fiffo’.


### download order

this test show the FIFO and LIFO download order

i created this local site:

	$ tree
	.
	├── a
	│   ├── a
	│   │   ├── a-a-x.jpg
	│   │   ├── a-a-y.jpg
	│   │   └── a-a.html
	│   ├── a-x.jpg
	│   ├── a-y.jpg
	│   ├── a.html
	│   └── b
	│       ├── a-b-x.jpg
	│       ├── a-b-y.jpg
	│       └── a-b.html
	├── b
	│   ├── a
	│   │   ├── b-a-x.jpg
	│   │   ├── b-a-y.jpg
	│   │   └── b-a.html
	│   ├── b
	│   │   ├── b-b-x.jpg
	│   │   ├── b-b-y.jpg
	│   │   └── b-b.html
	│   ├── b-x.jpg
	│   ├── b-y.jpg
	│   └── b.html
	├── i.html
	├── x.jpg
	└── y.jpg

	6 directories, 21 files

i.html

	<a href="a/a.html"><img src="x.jpg"></a>
	<a href="b/b.html"><img src="y.jpg"></a>

a.html

	<a href="a/a-a.html"><img src="a-x.jpg"></a>
	<a href="b/a-b.html"><img src="a-y.jpg"></a>
		
a-a.html

	<img src="a-a-x.jpg">
	<img src="a-a-y.jpg">
	
a-b.html

	<img src="a-b-x.jpg">
	<img src="a-b-y.jpg">
	
b.html

	<a href="a/b-a.html"><img src="b-x.jpg"></a>
	<a href="b/b-b.html"><img src="b-y.jpg"></a>
	
b-a.html

	<img src="b-a-x.jpg">
	<img src="b-a-y.jpg">
	
b-b.html

	<img src="b-b-x.jpg">
	<img src="b-b-y.jpg">
				
fifo download links long after its parent page. especially the deepest level links

	wget -vdrp -nd http://localhost/code/html/test/download/i.html 2>&1 | egrep "^Enqueuing|Dequeuing|Saving to"

	Enqueuing http://localhost/code/html/test/download/i.html at depth 0
	Dequeuing http://localhost/code/html/test/download/i.html at depth 0
	Saving to: ‘i.html’
	Enqueuing http://localhost/code/html/test/download/a/a.html at depth 1
	Enqueuing http://localhost/code/html/test/download/x.jpg at depth 1
	Enqueuing http://localhost/code/html/test/download/b/b.html at depth 1
	Enqueuing http://localhost/code/html/test/download/y.jpg at depth 1
	Dequeuing http://localhost/code/html/test/download/a/a.html at depth 1
	Saving to: ‘a.html’
	Enqueuing http://localhost/code/html/test/download/a/a/a-a.html at depth 2
	Enqueuing http://localhost/code/html/test/download/a/a-x.jpg at depth 2
	Enqueuing http://localhost/code/html/test/download/a/b/a-b.html at depth 2
	Enqueuing http://localhost/code/html/test/download/a/a-y.jpg at depth 2
	Dequeuing http://localhost/code/html/test/download/x.jpg at depth 1
	Saving to: ‘x.jpg’
	Dequeuing http://localhost/code/html/test/download/b/b.html at depth 1
	Saving to: ‘b.html’
	Enqueuing http://localhost/code/html/test/download/b/a/b-a.html at depth 2
	Enqueuing http://localhost/code/html/test/download/b/b-x.jpg at depth 2
	Enqueuing http://localhost/code/html/test/download/b/b/b-b.html at depth 2
	Enqueuing http://localhost/code/html/test/download/b/b-y.jpg at depth 2
	Dequeuing http://localhost/code/html/test/download/y.jpg at depth 1
	Saving to: ‘y.jpg’
	Dequeuing http://localhost/code/html/test/download/a/a/a-a.html at depth 2
	Saving to: ‘a-a.html’
	Enqueuing http://localhost/code/html/test/download/a/a/a-a-x.jpg at depth 3
	Enqueuing http://localhost/code/html/test/download/a/a/a-a-y.jpg at depth 3
	Dequeuing http://localhost/code/html/test/download/a/a-x.jpg at depth 2
	Saving to: ‘a-x.jpg’
	Dequeuing http://localhost/code/html/test/download/a/b/a-b.html at depth 2
	Saving to: ‘a-b.html’
	Enqueuing http://localhost/code/html/test/download/a/b/a-b-x.jpg at depth 3
	Enqueuing http://localhost/code/html/test/download/a/b/a-b-y.jpg at depth 3
	Dequeuing http://localhost/code/html/test/download/a/a-y.jpg at depth 2
	Saving to: ‘a-y.jpg’
	Dequeuing http://localhost/code/html/test/download/b/a/b-a.html at depth 2
	Saving to: ‘b-a.html’
	Enqueuing http://localhost/code/html/test/download/b/a/b-a-x.jpg at depth 3
	Enqueuing http://localhost/code/html/test/download/b/a/b-a-y.jpg at depth 3
	Dequeuing http://localhost/code/html/test/download/b/b-x.jpg at depth 2
	Saving to: ‘b-x.jpg’
	Dequeuing http://localhost/code/html/test/download/b/b/b-b.html at depth 2
	Saving to: ‘b-b.html’
	Enqueuing http://localhost/code/html/test/download/b/b/b-b-x.jpg at depth 3
	Enqueuing http://localhost/code/html/test/download/b/b/b-b-y.jpg at depth 3
	Dequeuing http://localhost/code/html/test/download/b/b-y.jpg at depth 2
	Saving to: ‘b-y.jpg’
	Dequeuing http://localhost/code/html/test/download/a/a/a-a-x.jpg at depth 3
	Saving to: ‘a-a-x.jpg’
	Dequeuing http://localhost/code/html/test/download/a/a/a-a-y.jpg at depth 3
	Saving to: ‘a-a-y.jpg’
	Dequeuing http://localhost/code/html/test/download/a/b/a-b-x.jpg at depth 3
	Saving to: ‘a-b-x.jpg’
	Dequeuing http://localhost/code/html/test/download/a/b/a-b-y.jpg at depth 3
	Saving to: ‘a-b-y.jpg’
	Dequeuing http://localhost/code/html/test/download/b/a/b-a-x.jpg at depth 3
	Saving to: ‘b-a-x.jpg’
	Dequeuing http://localhost/code/html/test/download/b/a/b-a-y.jpg at depth 3
	Saving to: ‘b-a-y.jpg’
	Dequeuing http://localhost/code/html/test/download/b/b/b-b-x.jpg at depth 3
	Saving to: ‘b-b-x.jpg’
	Dequeuing http://localhost/code/html/test/download/b/b/b-b-y.jpg at depth 3
	Saving to: ‘b-b-y.jpg’


lifo download links directly after its parent page

	wget -vdrp -nd --queue-type=lifo http://localhost/code/html/test/download/i.html 2>&1 | egrep "^Enqueuing|Dequeuing|Saving to"

	Enqueuing http://localhost/code/html/test/download/i.html at depth 0
	Dequeuing http://localhost/code/html/test/download/i.html at depth 0
	Saving to: ‘i.html’
	Enqueuing http://localhost/code/html/test/download/a/a.html at depth 1
	Enqueuing http://localhost/code/html/test/download/b/b.html at depth 1
	Enqueuing http://localhost/code/html/test/download/x.jpg at depth 1
	Enqueuing http://localhost/code/html/test/download/y.jpg at depth 1
	Dequeuing http://localhost/code/html/test/download/y.jpg at depth 1
	Saving to: ‘y.jpg’
	Dequeuing http://localhost/code/html/test/download/x.jpg at depth 1
	Saving to: ‘x.jpg’
	Dequeuing http://localhost/code/html/test/download/b/b.html at depth 1
	Saving to: ‘b.html’
	Enqueuing http://localhost/code/html/test/download/b/a/b-a.html at depth 2
	Enqueuing http://localhost/code/html/test/download/b/b/b-b.html at depth 2
	Enqueuing http://localhost/code/html/test/download/b/b-x.jpg at depth 2
	Enqueuing http://localhost/code/html/test/download/b/b-y.jpg at depth 2
	Dequeuing http://localhost/code/html/test/download/b/b-y.jpg at depth 2
	Saving to: ‘b-y.jpg’
	Dequeuing http://localhost/code/html/test/download/b/b-x.jpg at depth 2
	Saving to: ‘b-x.jpg’
	Dequeuing http://localhost/code/html/test/download/b/b/b-b.html at depth 2
	Saving to: ‘b-b.html’
	Enqueuing http://localhost/code/html/test/download/b/b/b-b-x.jpg at depth 3
	Enqueuing http://localhost/code/html/test/download/b/b/b-b-y.jpg at depth 3
	Dequeuing http://localhost/code/html/test/download/b/b/b-b-y.jpg at depth 3
	Saving to: ‘b-b-y.jpg’
	Dequeuing http://localhost/code/html/test/download/b/b/b-b-x.jpg at depth 3
	Saving to: ‘b-b-x.jpg’
	Dequeuing http://localhost/code/html/test/download/b/a/b-a.html at depth 2
	Saving to: ‘b-a.html’
	Enqueuing http://localhost/code/html/test/download/b/a/b-a-x.jpg at depth 3
	Enqueuing http://localhost/code/html/test/download/b/a/b-a-y.jpg at depth 3
	Dequeuing http://localhost/code/html/test/download/b/a/b-a-y.jpg at depth 3
	Saving to: ‘b-a-y.jpg’
	Dequeuing http://localhost/code/html/test/download/b/a/b-a-x.jpg at depth 3
	Saving to: ‘b-a-x.jpg’
	Dequeuing http://localhost/code/html/test/download/a/a.html at depth 1
	Saving to: ‘a.html’
	Enqueuing http://localhost/code/html/test/download/a/a/a-a.html at depth 2
	Enqueuing http://localhost/code/html/test/download/a/b/a-b.html at depth 2
	Enqueuing http://localhost/code/html/test/download/a/a-x.jpg at depth 2
	Enqueuing http://localhost/code/html/test/download/a/a-y.jpg at depth 2
	Dequeuing http://localhost/code/html/test/download/a/a-y.jpg at depth 2
	Saving to: ‘a-y.jpg’
	Dequeuing http://localhost/code/html/test/download/a/a-x.jpg at depth 2
	Saving to: ‘a-x.jpg’
	Dequeuing http://localhost/code/html/test/download/a/b/a-b.html at depth 2
	Saving to: ‘a-b.html’
	Enqueuing http://localhost/code/html/test/download/a/b/a-b-x.jpg at depth 3
	Enqueuing http://localhost/code/html/test/download/a/b/a-b-y.jpg at depth 3
	Dequeuing http://localhost/code/html/test/download/a/b/a-b-y.jpg at depth 3
	Saving to: ‘a-b-y.jpg’
	Dequeuing http://localhost/code/html/test/download/a/b/a-b-x.jpg at depth 3
	Saving to: ‘a-b-x.jpg’
	Dequeuing http://localhost/code/html/test/download/a/a/a-a.html at depth 2
	Saving to: ‘a-a.html’
	Enqueuing http://localhost/code/html/test/download/a/a/a-a-x.jpg at depth 3
	Enqueuing http://localhost/code/html/test/download/a/a/a-a-y.jpg at depth 3
	Dequeuing http://localhost/code/html/test/download/a/a/a-a-y.jpg at depth 3
	Saving to: ‘a-a-y.jpg’
	Dequeuing http://localhost/code/html/test/download/a/a/a-a-x.jpg at depth 3
	Saving to: ‘a-a-x.jpg’





