### PR TITLE
src/openssl.c (ssl_check_certificate): Build with -DOPENSSN_NO_DEPRECATED

### DIFF
--- a/src/openssl.c
+++ b/src/openssl.c
@@ -1044,7 +1044,11 @@ ssl_check_certificate (int fd, const char *host)
   if (opt.check_cert == CHECK_CERT_QUIET && pinsuccess)
     return success;
 
+#ifdef OPENSSL_NO_DEPRECATED_3_0
+  cert = SSL_get1_peer_certificate (conn);
+#else
   cert = SSL_get_peer_certificate (conn);
+#endif
   if (!cert)
     {
       logprintf (LOG_NOTQUIET, _("%s: No certificate presented by %s.\n"),


### PR DESCRIPTION
On embedded systems, deprecated API's are sometimes omitted to conserve space (both disk and memory).  While trying to build this on OpenWRT with `CONFIG_OPENSSL_NO_DEPRECATED` selected, I was getting errors about `SSL_get_peer_certificate()` not being defined.

It's a simple fix.
